### PR TITLE
Fix repetitive rules

### DIFF
--- a/src/arvan_client.py
+++ b/src/arvan_client.py
@@ -26,9 +26,20 @@ class ArvanClient:
         print(requests.post(f'{ARVAN_BASE_URL}/domains/{self.domain}/firewall/rules', json={
             'name': 'High request IP',
             'action': 'deny',
-            'is_enabled': True,
-            'note': 'Auto Block',
             'sources': [ip],
-            'url_pattern': '**',
+            'is_enabled': True,
+            'note': 'Auto Blocked by Bot',
+            'url_pattern': '**'
         }, headers=self.headers).json())
 
+    def get_firewall_rules(self):
+        return requests.get(f'{ARVAN_BASE_URL}/domains/{self.domain}/firewall', headers=self.headers).json()['data']
+
+    def is_IP_blocked(self, ip):
+        is_blocked = False
+        for rule in self.get_firewall_rules()['rules']:
+            if rule['action'] == 'deny':
+                for source in rule['sources']:
+                    if source == ip:
+                        is_blocked = True
+        return is_blocked

--- a/src/arvan_client.py
+++ b/src/arvan_client.py
@@ -26,10 +26,10 @@ class ArvanClient:
         print(requests.post(f'{ARVAN_BASE_URL}/domains/{self.domain}/firewall/rules', json={
             'name': 'High request IP',
             'action': 'deny',
-            'sources': [ip],
             'is_enabled': True,
-            'note': 'Auto Blocked by Bot',
-            'url_pattern': '**'
+            'note': 'Auto Block',
+            'sources': [ip],
+            'url_pattern': '**',
         }, headers=self.headers).json())
 
     def get_firewall_rules(self):

--- a/src/main.py
+++ b/src/main.py
@@ -32,8 +32,9 @@ def check_high_requests_ips_and_block():
         for row in high_req_ips:
             print('CHECK IP', row['ip'])
             if row['request_count'] > BLOCK_IP_THRESHOLD and row['ip'] not in WHITE_LIST_IPS:
-                print(f'BLOCK IP {row["ip"]} WITH {row["request_count"]} requests')
-                arvan_client.block_ip(row['ip'])
+                if not arvan_client.is_IP_blocked(row['ip']):
+                    print(f'BLOCK IP {row["ip"]} WITH {row["request_count"]} requests')
+                    arvan_client.block_ip(row['ip'])
         sleep(CHECK_INTERVAL)
 
 


### PR DESCRIPTION
There is no mechanism to check if a rule has been created before, resulting in repetitive rules in the panel.
I just added a check to look for the requested rule, if not exists then create it through an API call.

In the pictures below, you can see 2 rules with the same parameters results in duplicate rules with different IDs.

![Screenshot from 2021-01-29 12-45-15](https://user-images.githubusercontent.com/39435912/106255938-effdee00-621a-11eb-861a-cfa7991dddd9.png)
![Screenshot from 2021-01-29 12-45-03](https://user-images.githubusercontent.com/39435912/106255951-f4c2a200-621a-11eb-9489-332fbf0b0e25.png)

